### PR TITLE
CI: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Generate Xcode project (XcodeGen)
+        run: |
+          brew update
+          brew install xcodegen
+          xcodegen generate
+
       - name: Build (Release)
         run: |
           xcodebuild \


### PR DESCRIPTION
Adds a GitHub Actions workflow to build and attach a macOS .app zip to GitHub Releases when tagging v*.