### PR TITLE
UI polish: cohesive dark theme + editor left, preview right

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -78,11 +78,12 @@ struct ContentView: View {
             // Header
             Text("Files")
                 .font(.headline)
+                .foregroundColor(.white.opacity(0.92))
                 .padding(.horizontal, 16)
                 .padding(.vertical, 12)
-            
-            Divider()
-            
+
+            Divider().overlay(border)
+
             // Recent files list
             List {
                 if recentFiles.isEmpty {
@@ -94,11 +95,12 @@ struct ContentView: View {
                         Button(action: { openFile(url) }) {
                             HStack {
                                 Image(systemName: "doc.text")
-                                    .foregroundColor(.accentColor)
+                                    .foregroundColor(accent)
                                 Text(url.lastPathComponent)
                                     .lineLimit(1)
                                 Spacer()
                             }
+                            .foregroundColor(.white.opacity(0.85))
                         }
                         .buttonStyle(.plain)
                         .padding(.vertical, 2)
@@ -107,13 +109,16 @@ struct ContentView: View {
                 }
             }
             .listStyle(.sidebar)
-            
-            Divider()
-            
+            .scrollContentBackground(.hidden)
+            .background(panel)
+
+            Divider().overlay(border)
+
             // Open button
             Button(action: { showOpenPanel = true }) {
                 Label("Open File...", systemImage: "folder")
                     .frame(maxWidth: .infinity)
+                    .foregroundColor(.white.opacity(0.85))
             }
             .buttonStyle(.plain)
             .padding(12)
@@ -195,12 +200,12 @@ struct ContentView: View {
             Divider().overlay(border)
 
             HSplitView {
-                // Left: Preview
-                MarkdownPreviewView(markdown: filteredMarkdown, searchText: searchText)
+                // Left: Editor
+                editorView
                     .frame(minWidth: 350)
 
-                // Right: Editor
-                editorView
+                // Right: Preview
+                MarkdownPreviewView(markdown: filteredMarkdown, searchText: searchText)
                     .frame(minWidth: 350)
             }
         }

--- a/Sources/MarkdownPreviewView.swift
+++ b/Sources/MarkdownPreviewView.swift
@@ -16,7 +16,8 @@ struct MarkdownPreviewView: View {
                 MarkdownRenderedView(markdown: markdown, searchText: searchText)
             }
             .padding(28)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(maxWidth: 720, alignment: .leading) // Max width for readability
+            .frame(maxWidth: .infinity, alignment: .center)
         }
         .background(bg)
         .foregroundColor(text)
@@ -89,20 +90,23 @@ struct FullMarkdownView: View {
             Text(attString)
                 .font(.system(size: 28, weight: .bold))
                 .foregroundColor(.white.opacity(0.95))
-                .padding(.top, 16)
-                .padding(.bottom, 8)
+                .padding(.top, 24)
+                .padding(.bottom, 12)
+                .lineSpacing(4)
         case .heading2:
             Text(attString)
                 .font(.system(size: 24, weight: .bold))
                 .foregroundColor(.white.opacity(0.93))
-                .padding(.top, 14)
-                .padding(.bottom, 6)
+                .padding(.top, 20)
+                .padding(.bottom, 10)
+                .lineSpacing(3)
         case .heading3:
             Text(attString)
                 .font(.system(size: 20, weight: .semibold))
                 .foregroundColor(.white.opacity(0.92))
-                .padding(.top, 12)
-                .padding(.bottom, 4)
+                .padding(.top, 16)
+                .padding(.bottom, 8)
+                .lineSpacing(2)
         case .heading4:
             Text(attString)
                 .font(.system(size: 17, weight: .semibold))
@@ -110,23 +114,25 @@ struct FullMarkdownView: View {
                 .padding(.top, 8)
                 .padding(.bottom, 3)
         case .bullet:
-            HStack(alignment: .top, spacing: 8) {
+            HStack(alignment: .top, spacing: 10) {
                 Text("•")
                     .foregroundColor(Color(red: 0.36, green: 0.82, blue: 0.62))
                 Text(attString)
+                    .lineSpacing(4)
             }
+            .padding(.vertical, 2)
         case .numbered:
             Text(attString)
         case .codeBlock:
-            let codeBg = Color(red: 0.08, green: 0.09, blue: 0.12)
-            let codeBorder = Color.white.opacity(0.08)
+            let codeBg = Color(red: 0.11, green: 0.12, blue: 0.16) // Slightly lighter, Obsidian-like
+            let codeBorder = Color.white.opacity(0.12)
             Text(attString)
                 .font(.system(.body, design: .monospaced))
-                .padding(12)
+                .padding(16)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(codeBg)
-                .cornerRadius(8)
-                .overlay(RoundedRectangle(cornerRadius: 8).stroke(codeBorder))
+                .cornerRadius(10)
+                .overlay(RoundedRectangle(cornerRadius: 10).stroke(codeBorder))
         case .blockquote:
             HStack(alignment: .top, spacing: 8) {
                 Rectangle()
@@ -138,7 +144,7 @@ struct FullMarkdownView: View {
             .padding(.vertical, 4)
         case .paragraph:
             Text(attString)
-                .lineSpacing(4)
+                .lineSpacing(6)
         }
     }
     


### PR DESCRIPTION
Closes #7

- Unify dark metal palette across sidebar/topbar/editor/preview (remove light/white bleed)
- Improve contrast/hierarchy and preview typography
- Swap panes: editor left, preview right